### PR TITLE
Maintenance/update syn and quote

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,9 @@ keywords = ["derive", "deref"]
 repository = "https://github.com/sgrif/derive_deref"
 
 [dependencies]
-syn = "0.13"
-quote = "0.5"
+syn = "0.15"
+quote = "0.6"
+proc-macro2 = "0.4.24"
 
 [lib]
 proc-macro = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive_deref"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
 license = "MIT OR Apache-2.0"
 description = "Adds `#[derive(Deref)]` and `#[derive(DerefMut)]`"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate proc_macro;
+extern crate proc_macro2;
 #[macro_use]
 extern crate quote;
 extern crate syn;
@@ -45,12 +46,8 @@ pub fn derive_deref_mut(input: TokenStream) -> TokenStream {
     ).into()
 }
 
-fn parse_fields(item: &syn::DeriveInput, mutable: bool) -> (syn::Type, quote::Tokens) {
-    let trait_name = if mutable {
-        "DerefMut"
-    } else {
-        "Deref"
-    };
+fn parse_fields(item: &syn::DeriveInput, mutable: bool) -> (syn::Type, proc_macro2::TokenStream) {
+    let trait_name = if mutable { "DerefMut" } else { "Deref" };
     let fields = match item.data {
         syn::Data::Struct(ref body) => body.fields.iter().collect::<Vec<&syn::Field>>(),
         _ => panic!("#[derive({})] can only be used on structs", trait_name),
@@ -62,8 +59,8 @@ fn parse_fields(item: &syn::DeriveInput, mutable: bool) -> (syn::Type, quote::To
         panic!("#[derive({})] can only be used on structs with one field", trait_name)
     };
     let field_name = match fields[0].ident {
-        Some(ident) => quote!(#ident),
-        None => quote!(0)
+        Some(ref ident) => quote!(#ident),
+        None => quote!(0),
     };
 
     match (field_ty, mutable) {


### PR DESCRIPTION
Hiya, thanks for this crate.

Just bumped `syn` and `quote`, mainly to reduce compiling multiple versions of those crates in my project. Haven't bumped this crate's version numbers, so gotta do that before release.