### PR TITLE
Allow second field if it is `PhantomData`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,13 @@ fn parse_fields(item: &syn::DeriveInput, mutable: bool) -> (syn::Type, proc_macr
         _ => None,
     };
     let field_ty = field_ty
-        .unwrap_or_else(|| panic!("#[derive({})] can only be used on structs with one field", trait_name));
+        .unwrap_or_else(|| {
+            panic!(
+                "#[derive({})] can only be used on structs with one field, \
+                 and optionally a second `PhantomData` field.",
+                 trait_name,
+            )
+        });
 
     let field_name = match fields[0].ident {
         Some(ref ident) => quote!(#ident),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ extern crate quote;
 extern crate syn;
 
 use proc_macro::TokenStream;
+use syn::{Path, Type, TypePath};
 
 #[proc_macro_derive(Deref)]
 pub fn derive_deref(input: TokenStream) -> TokenStream {
@@ -53,11 +54,29 @@ fn parse_fields(item: &syn::DeriveInput, mutable: bool) -> (syn::Type, proc_macr
         _ => panic!("#[derive({})] can only be used on structs", trait_name),
     };
 
-    let field_ty = if fields.len() == 1 {
-        fields[0].ty.clone()
-    } else {
-        panic!("#[derive({})] can only be used on structs with one field", trait_name)
+    let field_ty = match fields.len() {
+        1 => Some(fields[0].ty.clone()),
+        2 => {
+            if let Type::Path(TypePath { path: Path { segments, .. }, .. }) = &fields[1].ty {
+                if segments
+                    .last()
+                    .expect("Expected path to have at least one segment")
+                    .value()
+                    .ident == "PhantomData"
+                {
+                    Some(fields[0].ty.clone())
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        },
+        _ => None,
     };
+    let field_ty = field_ty
+        .unwrap_or_else(|| panic!("#[derive({})] can only be used on structs with one field", trait_name));
+
     let field_name = match fields[0].ident {
         Some(ref ident) => quote!(#ident),
         None => quote!(0),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 extern crate derive_deref;
 
+use std::marker::PhantomData;
+
 #[test]
 fn derive_deref_tuple_struct() {
     #[derive(Deref)]
@@ -17,6 +19,17 @@ fn derive_deref_tuple_struct() {
 }
 
 #[test]
+fn derive_deref_tuple_struct_with_phantom_data() {
+    trait FooTrait<T> {}
+    impl FooTrait<()> for String {}
+
+    #[derive(Deref)]
+    struct FooWrapper<F, T>(F, PhantomData<T>) where F: FooTrait<T>;
+
+    assert_eq!("foo", &*FooWrapper(String::from("foo"), PhantomData));
+}
+
+#[test]
 fn derive_deref_named_struct() {
     #[derive(Deref)]
     struct StringWrapper { s: String };
@@ -29,6 +42,17 @@ fn derive_deref_named_struct() {
     assert_eq!(1, *IntWrapper { i: 1 });
     assert_eq!(&2, &*IntWrapper { i: 2 });
     assert_eq!(2, *IntWrapper { i: 2 });
+}
+
+#[test]
+fn derive_deref_named_struct_with_phantom_data() {
+    trait FooTrait<T> {}
+    impl FooTrait<()> for String {}
+
+    #[derive(Deref)]
+    struct FooNamedWrapper<F, T> where F: FooTrait<T> { f: F, phantom: PhantomData<T> };
+
+    assert_eq!("foo", &*FooNamedWrapper { f: String::from("foo"), phantom: PhantomData });
 }
 
 #[test]


### PR DESCRIPTION
Allows a second field to be present if it is `PhantomData`, fails otherwise.

@Eijebong hello, it's me again 🙃