### PR TITLE
Support multiple fields: deref_target attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ extern crate syn;
 use proc_macro::TokenStream;
 use syn::{Path, Type, TypePath};
 
-#[proc_macro_derive(Deref)]
+#[proc_macro_derive(Deref, attributes(deref_target))]
 pub fn derive_deref(input: TokenStream) -> TokenStream {
     let item = syn::parse(input).unwrap();
     let (field_ty, field_access) = parse_fields(&item, false);
@@ -28,7 +28,7 @@ pub fn derive_deref(input: TokenStream) -> TokenStream {
     ).into()
 }
 
-#[proc_macro_derive(DerefMut)]
+#[proc_macro_derive(DerefMut, attributes(deref_target))]
 pub fn derive_deref_mut(input: TokenStream) -> TokenStream {
     let item = syn::parse(input).unwrap();
     let (_, field_access) = parse_fields(&item, true);
@@ -50,45 +50,55 @@ pub fn derive_deref_mut(input: TokenStream) -> TokenStream {
 fn parse_fields(item: &syn::DeriveInput, mutable: bool) -> (syn::Type, proc_macro2::TokenStream) {
     let trait_name = if mutable { "DerefMut" } else { "Deref" };
     let fields = match item.data {
-        syn::Data::Struct(ref body) => body.fields.iter().collect::<Vec<&syn::Field>>(),
+        syn::Data::Struct(ref body) =>
+            body.fields.iter()
+                .filter(|field| {
+                    if let Type::Path(TypePath { path: Path { segments, .. }, .. }) = &field.ty {
+                        if segments
+                            .last()
+                            .expect("Expected path to have at least one segment")
+                            .ident == "PhantomData"
+                        {
+                            false
+                        } else {
+                            true
+                        }
+                    } else {
+                        true
+                    }
+                })
+                .collect::<Vec<&syn::Field>>(),
         _ => panic!("#[derive({})] can only be used on structs", trait_name),
     };
 
-    let field_ty = match fields.len() {
-        1 => Some(fields[0].ty.clone()),
-        2 => {
-            if let Type::Path(TypePath { path: Path { segments, .. }, .. }) = &fields[1].ty {
-                if segments
-                    .last()
-                    .expect("Expected path to have at least one segment")
-                    .ident == "PhantomData"
-                {
-                    Some(fields[0].ty.clone())
-                } else {
-                    None
+    let target_field = match fields.len() {
+        1 => fields[0],
+        _ => {
+            // Look for attribute
+            let mut targets = Vec::new();
+            for field in fields.iter() {
+                if let Some(_) = field.attrs.iter().find(|attr| attr.path.is_ident("deref_target")) {
+                    targets.push(field);
                 }
-            } else {
-                None
             }
-        },
-        _ => None,
-    };
-    let field_ty = field_ty
-        .unwrap_or_else(|| {
-            panic!(
-                "#[derive({})] can only be used on structs with one field, \
-                 and optionally a second `PhantomData` field.",
-                 trait_name,
-            )
-        });
+            match targets.len() {
+                0 => panic!("#[derive({})]: since there is more than one field, #[deref_target] is needed on a field", trait_name),
+                1 => targets[0],
+                _ => panic!("#[derive({})]: only one #[deref_target] allowed", trait_name),
+            }
 
-    let field_name = match fields[0].ident {
+        }
+    };
+
+
+
+    let field_name = match target_field.ident {
         Some(ref ident) => quote!(#ident),
         None => quote!(0),
     };
 
-    match (field_ty, mutable) {
-        (syn::Type::Reference(syn::TypeReference { elem, .. }), _) => (*elem.clone(), quote!(self.#field_name)),
+    match (target_field.ty.clone(), mutable) {
+        (syn::Type::Reference(syn::TypeReference { elem, .. }), _) => (*elem, quote!(self.#field_name)),
         (x, true) => (x, quote!(&mut self.#field_name)),
         (x, false) => (x, quote!(&self.#field_name)),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,15 +54,8 @@ fn parse_fields(item: &syn::DeriveInput, mutable: bool) -> (syn::Type, proc_macr
             body.fields.iter()
                 .filter(|field| {
                     if let Type::Path(TypePath { path: Path { segments, .. }, .. }) = &field.ty {
-                        if segments
-                            .last()
-                            .expect("Expected path to have at least one segment")
-                            .ident == "PhantomData"
-                        {
-                            false
-                        } else {
-                            true
-                        }
+                        let ident = &segments.last().expect("Expected path to have at least one segment").ident;
+                        ident != "PhantomData"
                     } else {
                         true
                     }
@@ -81,12 +74,7 @@ fn parse_fields(item: &syn::DeriveInput, mutable: bool) -> (syn::Type, proc_macr
                     targets.push(field);
                 }
             }
-            match targets.len() {
-                0 => panic!("#[derive({})]: since there is more than one field, #[deref_target] is needed on a field", trait_name),
-                1 => targets[0],
-                _ => panic!("#[derive({})]: only one #[deref_target] allowed", trait_name),
-            }
-
+            *targets.get(0).expect("#[deref_target] expected on one of the fields")
         }
     };
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,6 +4,29 @@ extern crate derive_deref;
 use std::marker::PhantomData;
 
 #[test]
+fn derive_deref_more_fields() {
+    #[derive(Deref)]
+    struct StringWrapper {
+        additional_data: i32,
+        more_data: i32,
+        #[deref_target]
+        inner: String,
+    };
+    assert_eq!("foo", &*StringWrapper {additional_data: 0, more_data: 0, inner: "foo".into()});
+}
+#[test]
+fn derive_deref_mut_more_fields() {
+    #[derive(Deref, DerefMut)]
+    struct StringWrapper {
+        additional_data: i32,
+        more_data: i32,
+        #[deref_target]
+        inner: String,
+    };
+    assert_eq!("foo", &*StringWrapper {additional_data: 0, more_data: 0, inner: "foo".into()});
+}
+
+#[test]
 fn derive_deref_tuple_struct() {
     #[derive(Deref)]
     struct StringWrapper(String);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -14,6 +14,7 @@ fn derive_deref_more_fields() {
     };
     assert_eq!("foo", &*StringWrapper {additional_data: 0, more_data: 0, inner: "foo".into()});
 }
+
 #[test]
 fn derive_deref_mut_more_fields() {
     #[derive(Deref, DerefMut)]


### PR DESCRIPTION
Use `deref_target` when there is more than one field to chose from (excluding any PhantomData, as before).
```
#[derive(Deref)]
struct StringWrapper {
    additional_data: i32,
    more_data: i32,
    #[deref_target]
    inner: String,
};
```

And update all dependencies to latest.